### PR TITLE
allow nested hashes to sign as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## Unpublished
+## Unpublished Version 2.0.0
 
 * Allow nested hashes/arrays to be signed.
+* Add :json message_format to sign a sorted json string, instead of just values.
 
 ## Version 1.0.4 / 2014-06-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unpublished
+
+* Allow nested hashes/arrays to be signed.
+
 ## Version 1.0.4 / 2014-06-20
 
 * Added HmacChecker#with_signature which returns the given hash with the HMAC merged in.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,57 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+```
+checker = Authmac::HmacChecker.new(secret, parameter_separator: '|', digest_function: 'sha1', message_format: :json)
+checker.with_signature(params_to_send)
+```
+
+* message_format: :values or :json. Format of message-string to sign. default :values.
+* digest_function: string to give `OpenSSL::Digest.new(digest_function)`
+* parameter_separator: Used for :values format to separate values.
+
+## Examples
+
+
+```
+params_to_sign = {
+  'some_param' => 'foo',
+  'other_param' => 'bar',
+  'timestamp'    => timestamp.to_s, # 12345678
+  'nonce'        => SecureRandom.urlsafe_base64(4), # ILFtHg
+  'consumer_key' => 'my_key'
+}
+```
+
+Classic syntax: signs values, sorted by key, joined by '|'
+
+```
+checker = Authmac::HmacChecker.new(ENV['consumer_secret'],
+							       parameter_separator: '|',
+							       digest_function: 'sha256')
+params_to_send = checker.with_signature(params_to_sign)
+
+checker.send(:message_string, params_to_sign) # "my_key|ILFtHg|bar|foo|123456789"
+```
+
+Syntax for more complex parameters, signs json, sorted by key (subhashes as well).
+
+```
+params_to_sign['some_param'] = {foo: [1, {bar: 2}]}
+```
+
+```
+checker = Authmac::HmacChecker.new(ENV['consumer_secret'],
+								   digest_function: 'sha256',
+								   message_format: :json)
+params_to_send = checker.with_signature(params_to_sign)
+
+checker.send(:message_string, params_to_sign)
+# '{"consumer_key":"my_key","nonce":"ILFtHg","other_params":"bar",' \
+# '"some_param":{"foo":["1",{"bar":"2"}]},"timestamp":"12345678"}'
+
+```
+
 
 ## Contributing
 

--- a/lib/authmac/hmac_checker.rb
+++ b/lib/authmac/hmac_checker.rb
@@ -2,10 +2,16 @@ require 'openssl'
 
 module Authmac
   class HmacChecker
-    def initialize(secret, parameter_separator = '|', digest_function = 'sha1')
+    # @param message_format [symbol] `:values` or `:json`.
+    #   `:json` will use a sorted json string to sign.
+    #   `:values` will use the sorted values separated by `parameter_separator` to sign.
+    def initialize(secret, message_format: :values,
+                           parameter_separator: '|',
+                           digest_function: 'sha1')
       @secret = secret
       @digest = digest_function
       @separator = parameter_separator
+      @message_format = message_format
       fail Authmac::SecretError, 'secret too short, see rfc2104' unless @secret.bytes.size >= digester.digest_length * 2
     end
 
@@ -28,20 +34,35 @@ module Authmac
     end
 
     def message_string(hash)
-      hash_values_sorted_by_key(hash).flatten.join(@separator)
+      fail ArgumentError, 'hash arg not a hash' unless hash.is_a? Hash
+
+      case @message_format
+      when :values
+        hash_values_sorted_by_key(hash).flatten.join(@separator)
+      when :json
+        require 'json'
+        JSON.generate(params_sorted_by_key(hash))
+      else
+        fail ArgumentError, 'unknown message_format'
+      end
     end
 
-    def hash_values_sorted_by_key(params)
+    def hash_values_sorted_by_key(hash)
+      hash.sort_by {|key, value| key }.map(&:last)
+    end
+
+    # stringifies and sorts hashes by key at all levels.
+    def params_sorted_by_key(params)
       case params
       when Hash
-        params.sort_by { |key, val| key }
-              .map { |key, val| hash_values_sorted_by_key(val) }
+        params.map     { |k, v| [k.to_s, params_sorted_by_key(v)] }
+              .sort_by { |k, v| k }
+              .to_h
       when Array
-        params.map { |val| hash_values_sorted_by_key(val) }
+        params.map { |val| params_sorted_by_key(val) }
       else
         params
       end
     end
   end
 end
-

--- a/lib/authmac/hmac_checker.rb
+++ b/lib/authmac/hmac_checker.rb
@@ -28,11 +28,17 @@ module Authmac
     end
 
     def message_string(hash)
-      hash_values_sorted_by_key(hash).join(@separator)
+      hash_values_sorted_by_key(hash).flatten.join(@separator)
     end
 
     def hash_values_sorted_by_key(hash)
-      hash.sort_by {|key, value| key }.map(&:last)
+      hash.sort_by {|key, value| key }.map do |_key, val|
+        if val.is_a? Hash
+          hash_values_sorted_by_key(val)
+        else
+          val
+        end
+      end
     end
   end
 end

--- a/lib/authmac/hmac_checker.rb
+++ b/lib/authmac/hmac_checker.rb
@@ -31,13 +31,15 @@ module Authmac
       hash_values_sorted_by_key(hash).flatten.join(@separator)
     end
 
-    def hash_values_sorted_by_key(hash)
-      hash.sort_by {|key, value| key }.map do |_key, val|
-        if val.is_a? Hash
-          hash_values_sorted_by_key(val)
-        else
-          val
-        end
+    def hash_values_sorted_by_key(params)
+      case params
+      when Hash
+        params.sort_by { |key, val| key }
+              .map { |key, val| hash_values_sorted_by_key(val) }
+      when Array
+        params.map { |val| hash_values_sorted_by_key(val) }
+      else
+        params
       end
     end
   end

--- a/spec/authmac/hmac_checker_spec.rb
+++ b/spec/authmac/hmac_checker_spec.rb
@@ -57,6 +57,18 @@ module Authmac
                                   hmacify('1|2|3|4'))).to be_truthy
         end
       end
+
+      context 'for a hash with nested hashes and arrays' do
+        it 'succeeds with correct hmac' do
+          expect(checker.validate({first: '1', second: {a: '2', b: ['3', '4']}, third: '5'},
+                                  hmacify('1|2|3|4|5'))).to be_truthy
+        end
+
+        it 'sorts hash values based on their keys' do
+          expect(checker.validate({first: '1', third: '6', second: {b: ['3', {c: '4', d: '5'}], a: '2'}},
+                                  hmacify('1|2|3|4|5|6'))).to be_truthy
+        end
+      end
     end
 
     describe '#with_signature' do

--- a/spec/authmac/hmac_checker_spec.rb
+++ b/spec/authmac/hmac_checker_spec.rb
@@ -2,11 +2,11 @@ require 'authmac/hmac_checker'
 
 module Authmac
   describe HmacChecker do
-    let(:checker) { HmacChecker.new('very secret random key of sufficient size', '|', 'sha1') }
+    let(:checker) { HmacChecker.new('very secret random key of sufficient size') }
 
     it 'raises an error for a secret shorter than the hmac output' do
       expect {
-        HmacChecker.new('way too short key', '|', 'sha1')
+        HmacChecker.new('way too short key')
       }.to raise_error SecretError, 'secret too short, see rfc2104'
     end
 
@@ -46,27 +46,39 @@ module Authmac
         end
       end
 
-      context 'for a hash with nested hashes' do
-        it 'succeeds with correct hmac' do
-          expect(checker.validate({first: '1', second: {a: '2', b: '3'}, third: '4'},
-                                  hmacify('1|2|3|4'))).to be_truthy
+      context 'with json message_string' do
+        let(:checker) { HmacChecker.new('very secret random key of sufficient size', message_format: :json) }
+
+        it 'creates a sorted json string' do
+          hash = {first: '1', third: '6', second: {b: ['3', {c: '4', d: '5'}], a: '2'}}
+          expect(checker.send :message_string, hash)
+            .to eq '{"first":"1","second":{"a":"2","b":["3",{"c":"4","d":"5"}]},"third":"6"}'
         end
 
-        it 'sorts hash values based on their keys' do
-          expect(checker.validate({first: '1', third: '4', second: {b: '3', a: '2'}},
-                                  hmacify('1|2|3|4'))).to be_truthy
-        end
-      end
+        context 'for a hash with nested hashes' do
+          it 'succeeds with correct hmac' do
+            expect(checker.validate({first: '1', second: {a: '2', b: '3'}, third: '4'},
+                                    hmacify('{"first":"1","second":{"a":"2","b":"3"},"third":"4"}'))).to be_truthy
+          end
 
-      context 'for a hash with nested hashes and arrays' do
-        it 'succeeds with correct hmac' do
-          expect(checker.validate({first: '1', second: {a: '2', b: ['3', '4']}, third: '5'},
-                                  hmacify('1|2|3|4|5'))).to be_truthy
+          it 'sorts hash values based on their keys' do
+            expect(checker.validate({first: '1', third: '4', second: {b: '3', a: '2'}},
+                                    hmacify('{"first":"1","second":{"a":"2","b":"3"},"third":"4"}'))).to be_truthy
+          end
         end
 
-        it 'sorts hash values based on their keys' do
-          expect(checker.validate({first: '1', third: '6', second: {b: ['3', {c: '4', d: '5'}], a: '2'}},
-                                  hmacify('1|2|3|4|5|6'))).to be_truthy
+        context 'for a hash with nested hashes and arrays' do
+          it 'succeeds with correct hmac' do
+            expect(checker.validate({first: '1', second: {a: '2', b: ['3', '4']}, third: '5'},
+                                    hmacify('{"first":"1","second":{"a":"2","b":["3","4"]},"third":"5"}')))
+                          .to be_truthy
+          end
+
+          it 'sorts hash values based on their keys' do
+            expect(checker.validate({first: '1', third: '6', second: {b: ['3', {c: '4', d: '5'}], a: '2'}},
+                                    hmacify( '{"first":"1","second":{"a":"2","b":["3",{"c":"4","d":"5"}]},"third":"6"}')))
+                          .to be_truthy
+          end
         end
       end
     end

--- a/spec/authmac/hmac_checker_spec.rb
+++ b/spec/authmac/hmac_checker_spec.rb
@@ -45,6 +45,18 @@ module Authmac
                                   hmacify('parameter|another'))).to be_truthy
         end
       end
+
+      context 'for a hash with nested hashes' do
+        it 'succeeds with correct hmac' do
+          expect(checker.validate({first: '1', second: {a: '2', b: '3'}, third: '4'},
+                                  hmacify('1|2|3|4'))).to be_truthy
+        end
+
+        it 'sorts hash values based on their keys' do
+          expect(checker.validate({first: '1', third: '4', second: {b: '3', a: '2'}},
+                                  hmacify('1|2|3|4'))).to be_truthy
+        end
+      end
     end
 
     describe '#with_signature' do


### PR DESCRIPTION
Not backward compatible. since it's moving to keyword arguments. 
Could add extra args to make it backwards compatible with warnings, but it's a small thing to change. 

Signing full json, but still sorted by keys, to prevent collisions.